### PR TITLE
Multiple IPs, performance updates, metrics updates, logging updates, license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/ansible/roles/ossh/tasks/main.yml
+++ b/ansible/roles/ossh/tasks/main.yml
@@ -49,6 +49,31 @@
     state: stopped
   tags: update
 
+- name: Get list of old sandboxes
+  become: yes
+  find:
+    paths: /etc/ossh/ffs/sandboxes
+    patterns: '*'
+    hidden: yes
+    file_type: directory
+  register: sandboxes_list
+
+- name: Unmount old sandboxes
+  mount:
+    path: "{{ item.path }}/merge-data"
+    state: unmounted
+  with_items: "{{ sandboxes_list.files }}"
+  ignore_errors: yes
+
+- name: Remove old sandboxes
+  become: yes
+  file:
+    path: "{{ item.path }}"
+    state: absent
+    force: yes
+  with_items: "{{ sandboxes_list.files }}"
+  ignore_errors: yes
+
 - name: Install oSSH binary
   copy:
     src: /tmp/ossh

--- a/ansible/roles/ossh/templates/config.yaml.j2
+++ b/ansible/roles/ossh/templates/config.yaml.j2
@@ -100,7 +100,7 @@ ratelimit: {{ ossh_ratelimit }}
 
 # Often bots run commands that produce little to no output. 
 # It's a shame to let them off the hook so easily. 
-# So we apply a delay of this many miliseconds per 
+# So we apply a delay of this many milliseconds per 
 # character of input before even evaluating the command.
 # Managed by Ansible.
 input_delay: {{ range(ossh_input_delay - ossh_input_delay_variability, ossh_input_delay + ossh_input_delay_variability) | random }}
@@ -136,8 +136,8 @@ sync_server:
 # Settings for the sync process.
 sync:
   # We sync with the other nodes in this interval of minutes. 
-  # Default is one sync every 10 minutes.
-  interval: 10 
+  # Default is one sync every 30 minutes.
+  interval: 30 
 
   # This is the list of nodes belonging to the cluster.
   # Managed by Ansible.

--- a/config.go
+++ b/config.go
@@ -103,7 +103,7 @@ type Config struct {
 var cfgFile string = ""
 var Conf Config
 
-var LogGlobal *glog.Logger = glog.NewLogger("Global", glog.Gray, false, false, false, logMessageHandler)
+var LogGlobal *glog.Logger = glog.NewLogger("Global", glog.Gray, false, logMessageHandler)
 
 func logMessageHandler(msg string) {
 	fmt.Print(msg)
@@ -122,7 +122,7 @@ func isIPWhitelisted(ip string) bool {
 }
 
 func colorConnID(user, host string, port int) string {
-	addr := glog.AddrHostPort(host, port, true)
+	addr := glog.AddrIPv4Port(host, port, true)
 	if user == "" {
 		return addr
 	}
@@ -199,7 +199,7 @@ func initConfig() {
 	InitTemplaterFunctions()
 	InitTemplaterFunctionsHTML()
 
-	LogGlobal.OK("Config loaded from %s", glog.Wrap(cfgFile, glog.Orange))
+	LogGlobal.OK("Config loaded from %s", glog.WrapOrange(cfgFile))
 }
 
 func getConfig() string {
@@ -219,15 +219,15 @@ func updateConfig(config []byte) error {
 	pathBak := fmt.Sprintf("%s.bak", pathSrc)
 	err := gutils.CopyFile(pathSrc, pathBak)
 	if err != nil {
-		LogGlobal.Error("Failed to backup config from %s to %s!", pathSrc, pathBak)
+		LogGlobal.Error("Failed to backup config from %s to %s!", glog.File(pathSrc), glog.File(pathBak))
 		return err
 	}
 	err = os.WriteFile(pathSrc, config, 0644)
 	if err != nil {
-		LogGlobal.Error("Failed to backup config from %s to %s!", pathSrc, pathBak)
+		LogGlobal.Error("Failed to backup config from %s to %s!", glog.File(pathSrc), glog.File(pathBak))
 		return err
 	}
-	LogGlobal.Success("Written new config to: %s", pathSrc)
+	LogGlobal.Success("Written new config to: %s", glog.File(pathSrc))
 
 	initConfig()
 	SrvSync.UpdateClients()

--- a/config.go
+++ b/config.go
@@ -14,13 +14,13 @@ import (
 )
 
 const (
-	INTERVAL_UI_STATS_UPDATE   = 10 * time.Second
-	INTERVAL_STATS_BROADCAST   = 60 * time.Second
-	INTERVAL_OVERLAYFS_CLEANUP = 30 * time.Second
-	INTERVAL_SESSIONS_CLEANUP  = 1 * time.Minute
-	INTERVAL_SYNC_CLEANUP      = 25 * time.Second
-	DELAY_OVERLAYFS_MKDIR      = 100 * time.Millisecond
-	CLEANUP_SYNC_MIN_AGE       = 60 * time.Second
+	INTERVAL_UI_STATS_UPDATE = 10 * time.Second
+	INTERVAL_STATS_BROADCAST = 60 * time.Second
+	// INTERVAL_OVERLAYFS_CLEANUP = 30 * time.Second
+	INTERVAL_SESSIONS_CLEANUP = 1 * time.Minute
+	INTERVAL_SYNC_CLEANUP     = 60 * time.Second
+	DELAY_OVERLAYFS_MKDIR     = 100 * time.Millisecond
+	CLEANUP_SYNC_MIN_AGE      = 120 * time.Second
 )
 
 var (

--- a/fake_file_system.go
+++ b/fake_file_system.go
@@ -57,7 +57,7 @@ type FakeFSManager struct {
 var embeddedFS embed.FS
 
 func (ofsm *FakeFSManager) Init(baseDir string) error {
-	ofsm.logger = glog.NewLogger("Fake FS", glog.LightBlue, Conf.Debug.OverlayFS, false, false, logMessageHandler)
+	ofsm.logger = glog.NewLogger("Fake FS", glog.LightBlue, Conf.Debug.OverlayFS, logMessageHandler)
 	ofsm.logger.Debug("Init %s", glog.File(baseDir))
 	if !gutils.DirExists(baseDir) {
 		err := os.Mkdir(baseDir, 0755)
@@ -190,18 +190,12 @@ func (ofsm *FakeFSManager) DeactivateOverlay(fs *FakeFS) {
 
 // https://windsock.io/the-overlay-filesystem/
 type FakeFS struct {
-	manager *FakeFSManager
-
-	logger *glog.Logger
-
-	// The dir containing the merged layers
-	mergedDir string
-	// The upper most layer, containing all changed made if any
-	upperDir string
-	// The work dir
-	workDir string
-	// The lower layers, ordered by time
-	lowerDirs []string
+	manager   *FakeFSManager
+	logger    *glog.Logger
+	mergedDir string   // The dir containing the merged layers
+	upperDir  string   // The upper most layer, containing all changed made if any
+	workDir   string   // The work dir
+	lowerDirs []string // The lower layers, ordered by time
 }
 
 func (ofs *FakeFS) Mount() error {

--- a/fake_shell.go
+++ b/fake_shell.go
@@ -349,7 +349,7 @@ func NewFakeShell(s *Session) *FakeShell {
 			User:             (*s.SSHSession).User(),
 			recording:        utils.NewASCIICastV2(fakeShellInitialWidth, fakeShellInitialHeight),
 		},
-		logger: glog.NewLogger("Fake Shell", glog.OliveGreen, Conf.Debug.FakeShell, false, false, logMessageHandler),
+		logger: glog.NewLogger("Fake Shell", glog.OliveGreen, Conf.Debug.FakeShell, logMessageHandler),
 	}
 
 	fs.terminal = term.NewTerminal(*s.SSHSession, "")

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/prometheus/client_golang v1.12.2
 	github.com/shawnohare/go-minhash v0.0.0-20160713203314-58d649feb1f9
 	github.com/spf13/viper v1.12.0
-	github.com/toxyl/glog v0.0.0-20220924165749-728e391e4499
+	github.com/toxyl/glog v1.0.0-alpha.1
 	github.com/toxyl/gutils v0.0.0-20220713042410-b539e3428793
 	golang.org/x/exp v0.0.0-20220706164943-b4a6d9510983
 	golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e

--- a/go.sum
+++ b/go.sum
@@ -255,10 +255,8 @@ github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/subosito/gotenv v1.4.0 h1:yAzM1+SmVcz5R4tXGsNMu1jUl2aOJXoiWUCEwwnGrvs=
 github.com/subosito/gotenv v1.4.0/go.mod h1:mZd6rFysKEcUhUHXJk0C/08wAgyDBFuwEYL7vWWGaGo=
-github.com/toxyl/glog v0.0.0-20220712190040-bd7dd7f54dfe h1:/baZ3rRmduqL2DU/FIwRBsYd0zWtuRx3ULipmsweP24=
-github.com/toxyl/glog v0.0.0-20220712190040-bd7dd7f54dfe/go.mod h1:Oo/Hv9YwDAdq6577wE/hUZ0uNJvBstLMF+rtsNNbgL8=
-github.com/toxyl/glog v0.0.0-20220924165749-728e391e4499 h1:GTke2E1Rk5RetOLXcPOL169+EMwind5vv3xLUbek+6Y=
-github.com/toxyl/glog v0.0.0-20220924165749-728e391e4499/go.mod h1:Oo/Hv9YwDAdq6577wE/hUZ0uNJvBstLMF+rtsNNbgL8=
+github.com/toxyl/glog v1.0.0-alpha.1 h1:F20r7tjnonykNrkuaEOAf5/efLWGogAFOGNIXt9i2M4=
+github.com/toxyl/glog v1.0.0-alpha.1/go.mod h1:9O3jnsSIofADRdzJ+7LN17N+NcmaoTSJvCsbFOQFjN8=
 github.com/toxyl/gutils v0.0.0-20220713042410-b539e3428793 h1:G5pkA32RPq/C7WXDtmyKOyRXCQnqb2fIgZ++M3LFBDI=
 github.com/toxyl/gutils v0.0.0-20220713042410-b539e3428793/go.mod h1:vwGE/QEaI/Elm2wzoFQ/YiDrI9qd7+jSq+CtzHz/p5M=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/grafana_dashboard.json
+++ b/grafana_dashboard.json
@@ -26,1097 +26,21 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": 2,
-  "iteration": 1657897891162,
+  "iteration": 1676414814859,
   "links": [],
   "liveNow": false,
   "panels": [
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${data}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "percentage",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 0,
-        "y": 0
-      },
-      "id": 244,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(ossh_time_online{instance=~\"$node\",job=~\"$job\"})",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "sum",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Time online",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${data}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "percentage",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 2,
-        "y": 0
-      },
-      "id": 245,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(ossh_time_wasted{instance=~\"$node\",job=~\"$job\"})",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "sum",
-          "range": true,
-          "refId": "C"
-        }
-      ],
-      "title": "Time wasted",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${data}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "percentage",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 4,
-        "y": 0
-      },
-      "id": 246,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg(ossh_time_wasted_per_second{instance=~\"$node\",job=~\"$job\"})",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "avg",
-          "range": true,
-          "refId": "D"
-        }
-      ],
-      "title": "Time wasted / s",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${data}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "percentage",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 6,
-        "y": 0
-      },
-      "id": 252,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(ossh_commands_executed{instance=~\"$node\",job=~\"$job\"})",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "sum",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Commands ",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${data}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "percentage",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 8,
-        "y": 0
-      },
-      "id": 248,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(ossh_logins{instance=~\"$node\",job=~\"$job\"})",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "sum",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Logins",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${data}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "percentage",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 10,
-        "y": 0
-      },
-      "id": 247,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(ossh_active_sessions{instance=~\"$node\",job=~\"$job\"})",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "sum",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Sessions",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${data}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "percentage",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 12,
-        "y": 0
-      },
-      "id": 251,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(go_goroutines{instance=~\"$node\",job=~\"$job\"})",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "sum",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Goroutines",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${data}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "percentage",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 14,
-        "y": 0
-      },
-      "id": 250,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(process_resident_memory_bytes{instance=~\"$node\",job=~\"$job\"})",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "sum",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "RAM",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${data}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "percentage",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 16,
-        "y": 0
-      },
-      "id": 253,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "max(ossh_known_hosts{instance=~\"$node\",job=~\"$job\"})",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "max",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Hosts",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${data}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "percentage",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 18,
-        "y": 0
-      },
-      "id": 254,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "max(ossh_known_users{instance=~\"$node\",job=~\"$job\"})",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "max",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Users",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${data}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "percentage",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 20,
-        "y": 0
-      },
-      "id": 255,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "max(ossh_known_passwords{instance=~\"$node\",job=~\"$job\"})",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "max",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Passwords",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${data}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "percentage",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 22,
-        "y": 0
-      },
-      "id": 256,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "max(ossh_known_payloads{instance=~\"$node\",job=~\"$job\"})",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "max",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Payloads",
-      "transparent": true,
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${data}"
-      },
-      "description": "Shows when and how often data has been added to the nodes. The brighter, the more data has been added at that point in time. (host, user, password, payload)",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 24,
-        "x": 0,
-        "y": 3
-      },
-      "id": 42,
-      "options": {
-        "calculate": false,
-        "cellGap": 0,
-        "cellValues": {
-          "unit": "none"
-        },
-        "color": {
-          "exponent": 0.5,
-          "fill": "dark-orange",
-          "min": 0,
-          "mode": "scheme",
-          "scale": "exponential",
-          "scheme": "Greens",
-          "steps": 128
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 0
-        },
-        "legend": {
-          "show": false
-        },
-        "rowsFrame": {
-          "layout": "unknown"
-        },
-        "tooltip": {
-          "show": true,
-          "yHistogram": false
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "reverse": false
-        }
-      },
-      "pluginVersion": "9.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(ossh_known_hosts{instance=~\"$node\",job=~\"$job\"}[$__interval]))",
-          "hide": false,
-          "legendFormat": "host",
-          "range": true,
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(ossh_known_users{instance=~\"$node\",job=~\"$job\"}[$__interval]))",
-          "hide": false,
-          "legendFormat": "user",
-          "range": true,
-          "refId": "E"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(ossh_known_passwords{instance=~\"$node\",job=~\"$job\"}[$__interval]))",
-          "hide": false,
-          "legendFormat": "password",
-          "range": true,
-          "refId": "F"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(ossh_known_payloads{instance=~\"$node\",job=~\"$job\"}[$__interval]))",
-          "hide": false,
-          "legendFormat": "payload",
-          "range": true,
-          "refId": "G"
-        }
-      ],
-      "transparent": true,
-      "type": "heatmap-new"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${data}"
-      },
-      "description": "Shows when and how often events happened. The brighter, the more events happened at that point in time. (session created, login finished, command executed)",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 24,
-        "x": 0,
-        "y": 6
-      },
-      "id": 359,
-      "options": {
-        "calculate": false,
-        "cellGap": 0,
-        "cellValues": {
-          "unit": "none"
-        },
-        "color": {
-          "exponent": 0.5,
-          "fill": "dark-orange",
-          "min": 0,
-          "mode": "scheme",
-          "scale": "exponential",
-          "scheme": "Greens",
-          "steps": 128
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 0
-        },
-        "legend": {
-          "show": false
-        },
-        "rowsFrame": {
-          "layout": "unknown"
-        },
-        "tooltip": {
-          "show": true,
-          "yHistogram": false
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "reverse": false
-        }
-      },
-      "pluginVersion": "9.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(ossh_active_sessions{instance=~\"$node\",job=~\"$job\"}[$__interval]))",
-          "hide": false,
-          "legendFormat": "session",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(ossh_logins{instance=~\"$node\",job=~\"$job\"}[$__interval]))",
-          "hide": false,
-          "legendFormat": "login",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(ossh_commands_executed{instance=~\"$node\",job=~\"$job\"}[$__interval]))",
-          "hide": false,
-          "legendFormat": "command",
-          "range": true,
-          "refId": "C"
-        }
-      ],
-      "transparent": true,
-      "type": "heatmap-new"
-    },
     {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 0
       },
-      "id": 48,
+      "id": 1034,
       "panels": [],
-      "title": "Nodes: $node",
+      "title": "Overview",
       "type": "row"
     },
     {
@@ -1176,13 +100,30 @@
           },
           "unit": "s"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "C"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 6,
         "w": 3,
         "x": 0,
-        "y": 10
+        "y": 1
       },
       "id": 53,
       "options": {
@@ -1242,6 +183,20 @@
           "legendFormat": "time online (max)",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ossh_time_online{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "time online (sum)",
+          "range": true,
+          "refId": "C"
         }
       ],
       "title": "Time online",
@@ -1304,13 +259,30 @@
           },
           "unit": "s"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "D"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 6,
         "w": 3,
         "x": 3,
-        "y": 10
+        "y": 1
       },
       "id": 75,
       "options": {
@@ -1371,6 +343,20 @@
           "legendFormat": "time wasted (max)",
           "range": true,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ossh_time_wasted{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "time wasted (sum)",
+          "range": true,
+          "refId": "D"
         }
       ],
       "title": "Time wasted",
@@ -1434,13 +420,30 @@
           },
           "unit": "s"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "D"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 6,
         "w": 3,
         "x": 6,
-        "y": 10
+        "y": 1
       },
       "id": 29,
       "options": {
@@ -1494,6 +497,18 @@
           "legendFormat": "time wasted / s (max)",
           "range": true,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "expr": "sum(ossh_time_wasted_per_second{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "legendFormat": "time wasted / s (sum)",
+          "range": true,
+          "refId": "D"
         }
       ],
       "title": "Time wasted / s",
@@ -1555,13 +570,30 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "D"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 6,
         "w": 3,
         "x": 9,
-        "y": 10
+        "y": 1
       },
       "id": 12,
       "options": {
@@ -1621,6 +653,20 @@
           "legendFormat": "commands / s (max)",
           "range": true,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ossh_commands_executed_per_second{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "commands / s (sum)",
+          "range": true,
+          "refId": "D"
         }
       ],
       "title": "Commands / s",
@@ -1685,13 +731,30 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "D"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 6,
         "w": 3,
         "x": 12,
-        "y": 10
+        "y": 1
       },
       "id": 114,
       "options": {
@@ -1752,6 +815,21 @@
           "legendFormat": "logins (max)",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ossh_logins_per_second{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "logins (sum)",
+          "range": true,
+          "refId": "D"
         }
       ],
       "title": "Logins / s",
@@ -1814,15 +892,33 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "D"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 6,
         "w": 3,
         "x": 15,
-        "y": 10
+        "y": 1
       },
       "id": 38,
       "options": {
@@ -1880,6 +976,19 @@
           "legendFormat": "sessions (max)",
           "range": true,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "expr": "sum(ossh_active_sessions{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "sessions (sum)",
+          "range": true,
+          "refId": "D"
         }
       ],
       "title": "Sessions",
@@ -1939,15 +1048,33 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "D"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 6,
         "w": 3,
         "x": 18,
-        "y": 10
+        "y": 1
       },
       "id": 113,
       "options": {
@@ -2004,6 +1131,20 @@
           "legendFormat": "goroutines (max)",
           "range": true,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(go_goroutines{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "goroutines (sum)",
+          "range": true,
+          "refId": "D"
         }
       ],
       "title": "Goroutines",
@@ -2066,15 +1207,32 @@
           },
           "unit": "bytes"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "D"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "hidden"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 6,
         "w": 3,
         "x": 21,
-        "y": 10
+        "y": 1
       },
-      "id": 43,
+      "id": 1415,
       "options": {
         "legend": {
           "calcs": [
@@ -2132,10 +1290,945 @@
           "legendFormat": "RAM (max)",
           "range": true,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(process_resident_memory_bytes{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "RAM (sum)",
+          "range": true,
+          "refId": "D"
         }
       ],
       "title": "RAM",
+      "transformations": [],
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 7
+      },
+      "id": 244,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "min(ossh_time_online{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "min",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(ossh_time_online{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "max",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(ossh_time_online{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "avg",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ossh_time_online{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "sum",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 7
+      },
+      "id": 245,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "min(ossh_time_wasted{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "min",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(ossh_time_wasted{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "max",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(ossh_time_wasted{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "avg",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ossh_time_wasted{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "sum",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 7
+      },
+      "id": 246,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "min(ossh_time_wasted_per_second{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "min",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(ossh_time_wasted_per_second{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "max",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(ossh_time_wasted_per_second{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "avg",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ossh_time_wasted_per_second{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "sum",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 7
+      },
+      "id": 842,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "min(ossh_commands_executed_per_second{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "min",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(ossh_commands_executed_per_second{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "max",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(ossh_commands_executed_per_second{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "avg",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ossh_commands_executed_per_second{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "sum",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 7
+      },
+      "id": 843,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "min(ossh_logins_per_second{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "min",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(ossh_logins_per_second{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "max",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(ossh_logins_per_second{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "avg",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ossh_logins_per_second{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "sum",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 15,
+        "y": 7
+      },
+      "id": 247,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "min(ossh_active_sessions{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "min",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(ossh_active_sessions{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "max",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(ossh_active_sessions{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "avg",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ossh_active_sessions{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "sum",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 18,
+        "y": 7
+      },
+      "id": 251,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "min(go_goroutines{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "min",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(go_goroutines{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "max",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(go_goroutines{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "avg",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(go_goroutines{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "sum",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 7
+      },
+      "id": 250,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "min(process_resident_memory_bytes{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "min",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(process_resident_memory_bytes{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "max",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(process_resident_memory_bytes{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "avg",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(process_resident_memory_bytes{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "sum",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
     },
     {
       "datasource": {
@@ -2197,10 +2290,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 10,
         "w": 3,
         "x": 0,
-        "y": 16
+        "y": 11
       },
       "id": 62,
       "options": {
@@ -2211,7 +2304,7 @@
           "displayMode": "table",
           "placement": "bottom",
           "sortBy": "Last *",
-          "sortDesc": true
+          "sortDesc": false
         },
         "tooltip": {
           "mode": "multi",
@@ -2226,9 +2319,9 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "ossh_time_online{instance=~\"$node\",job=~\"$job\"}",
+          "expr": "ossh_time_online{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\"}",
           "instant": false,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{name}}",
           "range": true,
           "refId": "Time Online"
         }
@@ -2304,10 +2397,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 10,
         "w": 3,
         "x": 3,
-        "y": 16
+        "y": 11
       },
       "id": 76,
       "options": {
@@ -2333,10 +2426,10 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "ossh_time_wasted{instance=~\"$node\",job=~\"$job\"}",
+          "expr": "ossh_time_wasted{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\"}",
           "hide": false,
           "instant": false,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{name}}",
           "range": true,
           "refId": "A"
         }
@@ -2413,10 +2506,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 10,
         "w": 3,
         "x": 6,
-        "y": 16
+        "y": 11
       },
       "id": 61,
       "options": {
@@ -2442,9 +2535,9 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "ossh_time_wasted_per_second{instance=~\"$node\",job=~\"$job\"}",
+          "expr": "ossh_time_wasted_per_second{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\"}",
           "format": "time_series",
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{name}}",
           "range": true,
           "refId": "A"
         }
@@ -2519,10 +2612,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 10,
         "w": 3,
         "x": 9,
-        "y": 16
+        "y": 11
       },
       "id": 60,
       "options": {
@@ -2548,9 +2641,9 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "ossh_commands_executed_per_second{instance=~\"$node\",job=~\"$job\"}",
+          "expr": "ossh_commands_executed_per_second{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\"}",
           "instant": false,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{name}}",
           "range": true,
           "refId": "A"
         }
@@ -2628,10 +2721,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 10,
         "w": 3,
         "x": 12,
-        "y": 16
+        "y": 11
       },
       "id": 118,
       "options": {
@@ -2657,11 +2750,11 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "ossh_logins_per_second{instance=~\"$node\",job=~\"$job\"}",
+          "expr": "ossh_logins_per_second{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\"}",
           "hide": false,
           "instant": false,
           "interval": "",
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{name}}",
           "range": true,
           "refId": "C"
         }
@@ -2734,15 +2827,16 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 10,
         "w": 3,
         "x": 15,
-        "y": 16
+        "y": 11
       },
       "id": 10,
       "options": {
@@ -2768,9 +2862,9 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "ossh_active_sessions{instance=~\"$node\",job=~\"$job\"}",
+          "expr": "ossh_active_sessions{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\"}",
           "instant": false,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{name}}",
           "range": true,
           "refId": "Active Sessions"
         }
@@ -2840,15 +2934,16 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 10,
         "w": 3,
         "x": 18,
-        "y": 16
+        "y": 11
       },
       "id": 116,
       "options": {
@@ -2874,9 +2969,9 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "go_goroutines{instance=~\"$node\",job=~\"$job\"}",
+          "expr": "go_goroutines{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\"}",
           "instant": false,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{name}}",
           "range": true,
           "refId": "A"
         }
@@ -2952,10 +3047,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 10,
         "w": 3,
         "x": 21,
-        "y": 16
+        "y": 11
       },
       "id": 59,
       "options": {
@@ -2981,9 +3076,9 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "process_resident_memory_bytes{instance=~\"$node\",job=~\"$job\"}",
+          "expr": "process_resident_memory_bytes{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\"}",
           "instant": false,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{name}}",
           "range": true,
           "refId": "A"
         }
@@ -3000,12 +3095,730 @@
       "type": "timeseries"
     },
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 651,
+      "panels": [],
+      "title": "Activity",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 0,
+        "y": 22
+      },
+      "id": 252,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ossh_commands_executed{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "commands",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 6,
+        "y": 22
+      },
+      "id": 248,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ossh_logins{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "logins",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 12,
+        "y": 22
+      },
+      "id": 844,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ossh_active_sessions{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "sessions",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data}"
+      },
+      "description": "Shows when and how often events happened. The brighter, the more events happened at that point in time. (session created, login finished, command executed)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-reds"
+          },
+          "custom": {
+            "fillOpacity": 70,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 652,
+      "options": {
+        "alignValue": "center",
+        "legend": {
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "mergeValues": false,
+        "rowHeight": 1,
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ossh_commands_executed{instance=~\"$node\",job=~\"$job\"}[$__interval]))",
+          "hide": false,
+          "legendFormat": "command",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ossh_logins{instance=~\"$node\",job=~\"$job\"}[$__interval]))",
+          "hide": false,
+          "legendFormat": "login",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ossh_active_sessions{instance=~\"$node\",job=~\"$job\"}[$__interval]))",
+          "hide": false,
+          "legendFormat": "session",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "transparent": true,
+      "type": "state-timeline"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 1223,
+      "panels": [],
+      "title": "Data Collection",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 0,
+        "y": 29
+      },
+      "id": 253,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(ossh_known_hosts{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "hosts",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 6,
+        "y": 29
+      },
+      "id": 254,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(ossh_known_users{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "users",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 12,
+        "y": 29
+      },
+      "id": 255,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(ossh_known_passwords{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "passwords",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 6,
+        "x": 18,
+        "y": 29
+      },
+      "id": 256,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(ossh_known_payloads{instance=~\"$node\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "payloads",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${data}"
+      },
+      "description": "Shows when and how often data has been added to the nodes. The brighter, the more data has been added at that point in time. (host, user, password, payload)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-reds"
+          },
+          "custom": {
+            "fillOpacity": 70,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 840,
+      "options": {
+        "alignValue": "center",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "mergeValues": false,
+        "rowHeight": 1,
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ossh_known_payloads{instance=~\"$node\",job=~\"$job\"}[$__interval]))",
+          "hide": false,
+          "legendFormat": "payload",
+          "range": true,
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ossh_known_passwords{instance=~\"$node\",job=~\"$job\"}[$__interval]))",
+          "hide": false,
+          "legendFormat": "password",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ossh_known_users{instance=~\"$node\",job=~\"$job\"}[$__interval]))",
+          "hide": false,
+          "legendFormat": "user",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(ossh_known_hosts{instance=~\"$node\",job=~\"$job\"}[$__interval]))",
+          "hide": false,
+          "legendFormat": "host",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "transparent": true,
+      "type": "state-timeline"
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 35
       },
       "id": 50,
       "panels": [
@@ -3014,7 +3827,7 @@
             "type": "prometheus",
             "uid": "${data}"
           },
-          "description": "",
+          "description": "Time online",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3055,8 +3868,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3069,7 +3881,7 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 5,
+            "h": 4,
             "w": 3,
             "x": 0,
             "y": 24
@@ -3099,7 +3911,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "ossh_time_online{instance=~\"$node\",job=~\"$job\"}",
+              "expr": "ossh_time_online{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\",name=~\"$host_name\"}",
               "hide": false,
               "instant": false,
               "legendFormat": "time online",
@@ -3107,7 +3919,7 @@
               "refId": "B"
             }
           ],
-          "title": "Time online",
+          "transparent": true,
           "type": "timeseries"
         },
         {
@@ -3115,7 +3927,7 @@
             "type": "prometheus",
             "uid": "${data}"
           },
-          "description": "",
+          "description": "Time wasted",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3155,8 +3967,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3169,7 +3980,7 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 5,
+            "h": 4,
             "w": 3,
             "x": 3,
             "y": 24
@@ -3199,7 +4010,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "ossh_time_wasted{instance=~\"$node\",job=~\"$job\"}",
+              "expr": "ossh_time_wasted{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\",name=~\"$host_name\"}",
               "hide": false,
               "instant": false,
               "legendFormat": "time wasted",
@@ -3207,7 +4018,7 @@
               "refId": "A"
             }
           ],
-          "title": "Time wasted",
+          "transparent": true,
           "type": "timeseries"
         },
         {
@@ -3215,7 +4026,7 @@
             "type": "prometheus",
             "uid": "${data}"
           },
-          "description": "Shows the ratio between time wasted and time online. Higher values = better.",
+          "description": "Time wasted/s (higher = better)",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3257,8 +4068,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3271,7 +4081,7 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 5,
+            "h": 4,
             "w": 3,
             "x": 6,
             "y": 24
@@ -3300,13 +4110,13 @@
                 "uid": "${data}"
               },
               "editorMode": "code",
-              "expr": "ossh_time_wasted_per_second{instance=~\"$node\",job=~\"$job\"}",
+              "expr": "ossh_time_wasted_per_second{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\",name=~\"$host_name\"}",
               "legendFormat": "time wasted / s",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Time wasted / s",
+          "transparent": true,
           "type": "timeseries"
         },
         {
@@ -3314,7 +4124,7 @@
             "type": "prometheus",
             "uid": "${data}"
           },
-          "description": "",
+          "description": "Commands/s",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3355,8 +4165,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3368,7 +4177,7 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 5,
+            "h": 4,
             "w": 3,
             "x": 9,
             "y": 24
@@ -3398,14 +4207,14 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "ossh_commands_executed_per_second{instance=~\"$node\",job=~\"$job\"}",
+              "expr": "ossh_commands_executed_per_second{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\",name=~\"$host_name\"}",
               "instant": false,
               "legendFormat": "commands / s",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Commands / s",
+          "transparent": true,
           "type": "timeseries"
         },
         {
@@ -3413,7 +4222,7 @@
             "type": "prometheus",
             "uid": "${data}"
           },
-          "description": "",
+          "description": "Logins/s",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3454,8 +4263,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3467,7 +4275,7 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 5,
+            "h": 4,
             "w": 3,
             "x": 12,
             "y": 24
@@ -3497,14 +4305,14 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "ossh_logins_per_second{instance=~\"$node\",job=~\"$job\"}",
+              "expr": "ossh_logins_per_second{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\",name=~\"$host_name\"}",
               "instant": false,
               "legendFormat": "logins / s",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Logins / s",
+          "transparent": true,
           "type": "timeseries"
         },
         {
@@ -3512,7 +4320,7 @@
             "type": "prometheus",
             "uid": "${data}"
           },
-          "description": "",
+          "description": "Sessions",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3556,20 +4364,20 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
                     "value": 80
                   }
                 ]
-              }
+              },
+              "unit": "short"
             },
             "overrides": []
           },
           "gridPos": {
-            "h": 5,
+            "h": 4,
             "w": 3,
             "x": 15,
             "y": 24
@@ -3598,7 +4406,7 @@
                 "uid": "${data}"
               },
               "editorMode": "code",
-              "expr": "ossh_active_sessions{instance=~\"$node\",job=~\"$job\"}",
+              "expr": "ossh_active_sessions{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\",name=~\"$host_name\"}",
               "hide": false,
               "interval": "",
               "legendFormat": "sessions",
@@ -3606,7 +4414,7 @@
               "refId": "B"
             }
           ],
-          "title": "Sessions",
+          "transparent": true,
           "type": "timeseries"
         },
         {
@@ -3614,103 +4422,7 @@
             "type": "prometheus",
             "uid": "${data}"
           },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "smooth",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "min": 0,
-              "noValue": "0",
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 3,
-            "x": 18,
-            "y": 24
-          },
-          "id": 135,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "hidden",
-              "placement": "bottom",
-              "sortBy": "Last *",
-              "sortDesc": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${data}"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "go_goroutines{instance=~\"$node\",job=~\"$job\"}",
-              "instant": false,
-              "legendFormat": "goroutines",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Goroutines",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${data}"
-          },
-          "description": "",
+          "description": "Goroutines",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3751,8 +4463,103 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 18,
+            "y": 24
+          },
+          "id": 135,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom",
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${data}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "go_goroutines{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\",name=~\"$host_name\"}",
+              "instant": false,
+              "legendFormat": "goroutines",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "transparent": true,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${data}"
+          },
+          "description": "RAM",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 35,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3765,7 +4572,7 @@
             "overrides": []
           },
           "gridPos": {
-            "h": 5,
+            "h": 4,
             "w": 3,
             "x": 21,
             "y": 24
@@ -3795,14 +4602,14 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "process_resident_memory_bytes{instance=~\"$node\",job=~\"$job\"}",
+              "expr": "process_resident_memory_bytes{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\",name=~\"$host_name\"}",
               "instant": false,
               "legendFormat": "RAM",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "RAM",
+          "transparent": true,
           "type": "timeseries"
         },
         {
@@ -3821,8 +4628,7 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3838,7 +4644,7 @@
             "h": 2,
             "w": 3,
             "x": 0,
-            "y": 29
+            "y": 28
           },
           "id": 120,
           "options": {
@@ -3863,7 +4669,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "ossh_time_online{instance=~\"$node\",job=~\"$job\"}",
+              "expr": "ossh_time_online{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\",name=~\"$host_name\"}",
               "hide": false,
               "instant": false,
               "interval": "",
@@ -3891,8 +4697,7 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3908,7 +4713,7 @@
             "h": 2,
             "w": 3,
             "x": 3,
-            "y": 29
+            "y": 28
           },
           "id": 121,
           "options": {
@@ -3933,7 +4738,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "ossh_time_wasted{instance=~\"$node\",job=~\"$job\"}",
+              "expr": "ossh_time_wasted{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\",name=~\"$host_name\"}",
               "hide": false,
               "instant": false,
               "interval": "",
@@ -3961,8 +4766,7 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3978,7 +4782,7 @@
             "h": 2,
             "w": 3,
             "x": 6,
-            "y": 29
+            "y": 28
           },
           "id": 122,
           "options": {
@@ -4003,7 +4807,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "ossh_time_wasted_per_second{instance=~\"$node\",job=~\"$job\"}",
+              "expr": "ossh_time_wasted_per_second{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\",name=~\"$host_name\"}",
               "hide": false,
               "instant": false,
               "interval": "",
@@ -4026,14 +4830,12 @@
               "color": {
                 "mode": "palette-classic"
               },
-              "decimals": 3,
               "mappings": [],
               "thresholds": {
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4041,7 +4843,7 @@
                   }
                 ]
               },
-              "unit": "none"
+              "unit": "short"
             },
             "overrides": []
           },
@@ -4049,7 +4851,7 @@
             "h": 2,
             "w": 3,
             "x": 9,
-            "y": 29
+            "y": 28
           },
           "id": 124,
           "options": {
@@ -4074,11 +4876,11 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "ossh_commands_executed_per_second{instance=~\"$node\",job=~\"$job\"}",
+              "expr": "ossh_commands_executed{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\",name=~\"$host_name\"}",
               "hide": false,
               "instant": false,
               "interval": "",
-              "legendFormat": "commands / s",
+              "legendFormat": "commands",
               "range": true,
               "refId": "C"
             }
@@ -4102,8 +4904,7 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4111,7 +4912,7 @@
                   }
                 ]
               },
-              "unit": "none"
+              "unit": "short"
             },
             "overrides": []
           },
@@ -4119,7 +4920,7 @@
             "h": 2,
             "w": 3,
             "x": 12,
-            "y": 29
+            "y": 28
           },
           "id": 125,
           "options": {
@@ -4144,7 +4945,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "ossh_logins_per_second{instance=~\"$node\",job=~\"$job\"}",
+              "expr": "ossh_logins{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\",name=~\"$host_name\"}",
               "hide": false,
               "instant": false,
               "interval": "",
@@ -4172,8 +4973,7 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4181,7 +4981,7 @@
                   }
                 ]
               },
-              "unit": "none"
+              "unit": "short"
             },
             "overrides": []
           },
@@ -4189,7 +4989,7 @@
             "h": 2,
             "w": 3,
             "x": 15,
-            "y": 29
+            "y": 28
           },
           "id": 123,
           "options": {
@@ -4214,7 +5014,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "ossh_active_sessions{instance=~\"$node\",job=~\"$job\"}",
+              "expr": "ossh_active_sessions{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\",name=~\"$host_name\"}",
               "hide": false,
               "instant": false,
               "interval": "",
@@ -4242,8 +5042,7 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4251,7 +5050,7 @@
                   }
                 ]
               },
-              "unit": "none"
+              "unit": "short"
             },
             "overrides": []
           },
@@ -4259,7 +5058,7 @@
             "h": 2,
             "w": 3,
             "x": 18,
-            "y": 29
+            "y": 28
           },
           "id": 127,
           "options": {
@@ -4284,7 +5083,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "go_goroutines{instance=~\"$node\",job=~\"$job\"}",
+              "expr": "go_goroutines{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\",name=~\"$host_name\"}",
               "hide": false,
               "instant": false,
               "interval": "",
@@ -4312,8 +5111,7 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4329,7 +5127,7 @@
             "h": 2,
             "w": 3,
             "x": 21,
-            "y": 29
+            "y": 28
           },
           "id": 126,
           "options": {
@@ -4354,7 +5152,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "process_resident_memory_bytes{instance=~\"$node\",job=~\"$job\"}",
+              "expr": "process_resident_memory_bytes{instance=~\"$node\",job=~\"$job\"} * on(instance) group_left(name) ossh_host_info{instance=~\"$node\",job=~\"$job\",name=~\"$host_name\"}",
               "hide": false,
               "instant": false,
               "interval": "",
@@ -4367,13 +5165,13 @@
           "type": "stat"
         }
       ],
-      "repeat": "node",
+      "repeat": "host_name",
       "repeatDirection": "h",
-      "title": "Node: $node",
+      "title": "Node: $host_name",
       "type": "row"
     }
   ],
-  "refresh": "10s",
+  "refresh": "5m",
   "schemaVersion": 36,
   "style": "dark",
   "tags": [
@@ -4464,11 +5262,42 @@
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${data}"
+        },
+        "definition": "ossh_host_info{job=~\"$job\",instance=~\"$node\"}",
+        "hide": 2,
+        "includeAll": true,
+        "label": "Host Name",
+        "multi": true,
+        "name": "host_name",
+        "options": [],
+        "query": {
+          "query": "ossh_host_info{job=~\"$job\",instance=~\"$node\"}",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/.*name=\"(.*?)\".*/",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
       }
     ]
   },
   "time": {
-    "from": "now-24h",
+    "from": "now-7d",
     "to": "now"
   },
   "timepicker": {
@@ -4488,6 +5317,6 @@
   "timezone": "browser",
   "title": "oSSH Cluster",
   "uid": "7Cx4oO6nz",
-  "version": 49,
+  "version": 85,
   "weekStart": "monday"
 }

--- a/ossh_sessions.go
+++ b/ossh_sessions.go
@@ -237,7 +237,7 @@ func (ss *Sessions) Create(sessionID string) *Session {
 	defer ss.Unlock()
 
 	if !ss.has(sessionID) {
-		s := NewSession(glog.NewLogger("Sessions", glog.DarkOrange, Conf.Debug.Sessions, false, false, logMessageHandler)).SetID(sessionID)
+		s := NewSession(glog.NewLogger("Sessions", glog.DarkOrange, Conf.Debug.Sessions, logMessageHandler)).SetID(sessionID)
 		if s == nil {
 			return nil
 		}
@@ -279,24 +279,24 @@ func (ss *Sessions) Remove(sessionID, reason string) {
 			if cnts == 0 {
 				ss.logger.OK(
 					"%s: Session removed, host has no more active sessions. It was active for %s.",
-					cid, glog.Duration(uint(tw)),
+					cid, glog.Duration(tw),
 				)
 			} else {
 				ss.logger.OK(
 					"%s: Session removed, host now uses %s of %s. It was active for %s.",
-					cid, glog.Int(active), glog.IntAmount(cnts, "active session", "active sessions"), glog.Duration(uint(tw)),
+					cid, glog.Int(active), glog.IntAmount(cnts, "active session", "active sessions"), glog.Duration(tw),
 				)
 			}
 		} else {
 			if cnts == 0 {
 				ss.logger.OK(
 					"%s: Session removed, host has no more active sessions. It was active for %s and removed because %s.",
-					cid, glog.Int(active), glog.IntAmount(cnts, "active session", "active sessions"), glog.Duration(uint(tw)), glog.Reason(reason),
+					cid, glog.Int(active), glog.IntAmount(cnts, "active session", "active sessions"), glog.Duration(tw), glog.Reason(reason),
 				)
 			} else {
 				ss.logger.OK(
 					"%s: Session removed, host now uses %s of %s. It was active for %s and removed because %s.",
-					cid, glog.Int(active), glog.IntAmount(cnts, "active session", "active sessions"), glog.Duration(uint(tw)), glog.Reason(reason),
+					cid, glog.Int(active), glog.IntAmount(cnts, "active session", "active sessions"), glog.Duration(tw), glog.Reason(reason),
 				)
 			}
 		}

--- a/ossh_sessions.go
+++ b/ossh_sessions.go
@@ -258,11 +258,6 @@ func (ss *Sessions) Remove(sessionID, reason string) {
 	defer ss.Unlock()
 	if ss.has(sessionID) {
 		s := ss.get(sessionID)
-
-		if s.Shell != nil && s.Shell.overlayFS != nil {
-			s.Shell.overlayFS.Close()
-		}
-
 		sh := s.Host
 		tw := 0
 		cid := colorConnID("", sh, s.Port)
@@ -281,13 +276,29 @@ func (ss *Sessions) Remove(sessionID, reason string) {
 		active := ss.countActiveSessions(sh)
 
 		if reason == "" {
-			ss.logger.OK(
-				"%s: Session removed, host now uses %s of %s. It was active for %s.",
-				cid, glog.Int(active), glog.IntAmount(cnts, "active session", "active sessions"), glog.Duration(uint(tw)))
+			if cnts == 0 {
+				ss.logger.OK(
+					"%s: Session removed, host has no more active sessions. It was active for %s.",
+					cid, glog.Duration(uint(tw)),
+				)
+			} else {
+				ss.logger.OK(
+					"%s: Session removed, host now uses %s of %s. It was active for %s.",
+					cid, glog.Int(active), glog.IntAmount(cnts, "active session", "active sessions"), glog.Duration(uint(tw)),
+				)
+			}
 		} else {
-			ss.logger.OK(
-				"%s: Session removed, host now uses %s of %s. It was active for %s and removed because %s.",
-				cid, glog.Int(active), glog.IntAmount(cnts, "active session", "active sessions"), glog.Duration(uint(tw)), glog.Reason(reason))
+			if cnts == 0 {
+				ss.logger.OK(
+					"%s: Session removed, host has no more active sessions. It was active for %s and removed because %s.",
+					cid, glog.Int(active), glog.IntAmount(cnts, "active session", "active sessions"), glog.Duration(uint(tw)), glog.Reason(reason),
+				)
+			} else {
+				ss.logger.OK(
+					"%s: Session removed, host now uses %s of %s. It was active for %s and removed because %s.",
+					cid, glog.Int(active), glog.IntAmount(cnts, "active session", "active sessions"), glog.Duration(uint(tw)), glog.Reason(reason),
+				)
+			}
 		}
 	}
 }

--- a/sync_client.go
+++ b/sync_client.go
@@ -178,7 +178,7 @@ func NewSyncClient(host string, port int) *SyncClient {
 	sc := &SyncClient{
 		Host:   host,
 		Port:   port,
-		logger: glog.NewLogger("Sync Client", glog.Blue, Conf.Debug.SyncClient, false, false, logMessageHandler),
+		logger: glog.NewLogger("Sync Client", glog.Blue, Conf.Debug.SyncClient, logMessageHandler),
 		lock:   &sync.Mutex{},
 	}
 	return sc

--- a/sync_nodes.go
+++ b/sync_nodes.go
@@ -188,7 +188,7 @@ func NewSyncNodes() *SyncNodes {
 		nodes:   map[string]*SyncNode{},
 		clients: map[string]*SyncClient{},
 		stats:   map[string]*SyncNodeStats{},
-		logger:  glog.NewLogger("Sync Server", glog.DarkRed, Conf.Debug.SyncServer, false, false, logMessageHandler),
+		logger:  glog.NewLogger("Sync Server", glog.DarkRed, Conf.Debug.SyncServer, logMessageHandler),
 		lock:    &sync.Mutex{},
 	}
 }

--- a/templater_text.go
+++ b/templater_text.go
@@ -17,7 +17,7 @@ import (
 	"github.com/toxyl/gutils"
 )
 
-var LogTextTemplater *glog.Logger = glog.NewLogger("Text Templater", glog.MediumGray, false, false, false, logMessageHandler)
+var LogTextTemplater *glog.Logger = glog.NewLogger("Text Templater", glog.MediumGray, false, logMessageHandler)
 
 var templateFunctions template.FuncMap = template.FuncMap{}
 


### PR DESCRIPTION
- implemented listening to multiple IPs
- changed to a single sandbox per launch (avoids excessive memory use when bots start hundreds of connections that require a file system)
- changed default sync interval to 30 minutes to reduce sync load when using a lot of nodes
- reduced default sync connection cleanup to once per minute and the min age has been increased to 2 minutes
- simplified overlay fs
- added host info to metrics
- disabled syncing credentials immediately (fixes a lot of sync connections being opened if bots start hundreds of connections in a short time frame)
- changed public key behavior to reject all known keys (reduces load when bots start hundreds of logins with existing public keys)
- added regular stats print out to log
- added LICENSE
- updated glog dependency
- updated Grafana dashboard